### PR TITLE
Metrics return consistency and fast pitch control

### DIFF
--- a/R/control.R
+++ b/R/control.R
@@ -17,23 +17,30 @@ pitch_control <- function(tracking, grid = c(120, 80), cells = 200) {
   }
 
   players <- as_position(tracking, ball = FALSE, expand = TRUE)
-  team_id <- vec_group_loc(get_team(players))
 
   # metrics
-  lo <- lapply(asplit(get_location(players), 1), as.numeric)
-  mu <- asplit(expected_position(players), 1)
+  lo <- get_location(players)
+  mu <- expected_location(players)
   sr <- speed_ratio(players)
   ir <- influence_radius(as_position(tracking, expand = TRUE))
+  th <- theta(players)
+
+  # NA handling
+  undefined <- is.na(th)
+  lo <- lo[!undefined, ]
+  mu <- mu[!undefined, ]
+  sr <- sr[!undefined]
+  ir <- ir[!undefined]
+  th <- th[!undefined]
 
   # rotation and scaling matrices
   rotation <- lapply(
-    theta(players),
+    th,
     function(x) matrix(c(cos(x), sin(x), -sin(x), cos(x)), nrow = 2)
   )
 
-  scaling <- purrr::pmap( # t(ir)
-    list(as.numeric((1 + c(sr)) * c(ir) / 2),
-         as.numeric((1 - c(sr)) * c(ir) / 2)),
+  scaling <- purrr::pmap(
+    list((1 + sr) * ir / 2, (1 - sr) * ir / 2),
     function(x, y) matrix(c(x, 0, 0, y), nrow = 2)
   )
 
@@ -44,38 +51,40 @@ pitch_control <- function(tracking, grid = c(120, 80), cells = 200) {
   )
 
   # pitch grid
-  pitch <- expand.grid(
-    x = seq(0, grid[1], length.out = cells),
-    y = seq(0, grid[2], length.out = cells)
+  pitch <- as.matrix(
+    CJ(x = seq(0, grid[1], length.out = cells),
+       y = seq(0, grid[2], length.out = cells),
+       sorted = FALSE, unique = TRUE)
   )
 
   # influence by player for each pitch cell
   pitch_influence <- purrr::pmap(
-    list(mu, sigma),
-    function(x, y) mvtnorm::dmvnorm(pitch, x, y)
+    list(asplit(mu, 1), sigma),
+    function(x, y) Rfast::dmvnorm(pitch, x, y)
   )
 
   location_influence <- purrr::pmap_dbl(
-    list(lo, mu, sigma),
-    function(x, y, z) mvtnorm::dmvnorm(x, y, z)
+    list(asplit(lo, 1), asplit(mu, 1), sigma),
+    function(x, y, z) Rfast::dmvnorm(x, y, z)
   )
 
   influence <- do.call(cbind, pitch_influence) %*%
     Matrix::Diagonal(x = 1 / location_influence)
 
   # multiply by -1 for summation convenience
+  team_id <- vec_group_loc(get_team(players)[!undefined])
+  time <- get_time(players)[!undefined]
   influence[, team_id[[1, 2]]] <- influence[, team_id[[1, 2]]] * -1
-  summation <- rowsum(t(as.matrix(influence)), get_time(players), na.rm = TRUE)
+  summation <- rowsum(t(as.matrix(influence)), time, na.rm = TRUE)
   pc <- 1 / (1 + exp(summation))
 
   # return
-  res <- data.table(
-    time = rep(vec_unique(get_time(tracking)), each = vec_size(pitch)),
+  data.table(
+    time = rep(vec_unique(time), each = vec_size(pitch)),
     pitch,
     control = c(t(pc))
   )
 
-  res[time != min(time) & stats::complete.cases(res)]
+  # res[time != min(time) & stats::complete.cases(res)]
 
 }
-

--- a/R/metrics.R
+++ b/R/metrics.R
@@ -215,15 +215,16 @@ speed_ratio <- function(p, max_speed = 13) {
   }
 
   s <- speed(p)
-  (s[, "xy", drop = FALSE] / max_speed)**2
+  (s[, "xy"] / 13)**2
+
 }
 
-#' Calculate expected position of an entity
+#' Calculate expected location of an entity
 #'
 #' @param p A position vector.
 #
 #' @return An array with `length(p)` rows and columns "x" and "y".
-expected_position <- function(p) {
+expected_location <- function(p) {
 
   if (!is_position(p)) {
     abort("`p` must be a position vector.")
@@ -246,26 +247,15 @@ influence_radius <- function(p) {
     abort("`p` must be a position vector.")
   }
 
-  d <- distance(
-    p, from = setdiff(vec_unique(get_entity(p)), "ball"), to = "ball"
-  )[, , , "xy"]
+  players <- setdiff(get_entity(p), "ball")
+  d <- distance(p, from = players, to = "ball")[, , , "xy"]
+  ir <- pmin(4 + ((d^3) / ((18^3) / 6)), 10)
 
-  ri <- pmin(4 + ((d^3) / ((18^3) / 6)), 10)
-
-  matrix(
-    data = c(t(ri)),
-    ncol = 1,
-    dimnames = list(get_entity(p)[get_entity(p) != "ball"])
-  )
-
-  # as.matrix(
-  #   melt(
-  #     as.data.table(ri, keep.rownames = "entity"),
-  #     id.vars = "entity", variable.name = "time", variable.factor = FALSE
-  #   )[order(entity, time), .(entity, value, time = as.numeric(time))],
-  #   rownames = "entity"
-  # )
+  # return named vector
+  nm <- rep(row.names(ir), each = ncol(ir))
+  ir <- as.numeric(t(ir))
+  names(ir) <- nm
+  ir
 
 }
-
 


### PR DESCRIPTION
Ensured consistency in metrics return values (vector for 1 dimension, matrix for 2 dimensions, arrays for 3 or more dimensions).

Switched pitch_control() to Rfast::dmvnorm for speed enhancement. Improved NA handling to remove redundant calculations.